### PR TITLE
Fix imported interface that have gd-impl directive not having correct import path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1949,6 +1949,7 @@ fn resolve_type_decl(
                 result.decl = Some(ResolutionDecl::TsInterfaceDecl(intf.to_owned()));
                 result.decl_context = Some(context.clone());
                 result.ctor_type = Some(result.type_name.clone());
+                result.gd_impl = have_directive(global, context, GD_IMPL_DIRECTIVE);
                 Some(result)
             } else {
                 None
@@ -3943,6 +3944,33 @@ mod tests {
     }
 
     #[test]
+    fn gd_impl_directive_imported_interface() {
+        let any_kind_src = "
+            /* @typescript-to-gdscript-gd-impl */
+            export interface SomeInterface {
+                interfaceValue: AKind | BKind;
+            }
+        ";
+        let src = "
+            import { SomeInterface } from \"./impl-interface.js\";
+            export interface A {
+                a: SomeInterface;
+            }
+        ";
+        let models = parse_and_get_models_with_imports(
+            "gd-impl-directive-imported-interface.ts",
+            &src,
+            &[&parse_from_string("impl-interface.ts", any_kind_src)],
+        );
+        assert_eq!(models.len(), 1);
+        let model = models.get(0).unwrap();
+        assert_eq!(model.imports.len(), 1);
+        let import = model.imports.get(0).unwrap();
+        assert_eq!(import.src, "some_interface.gd");
+        assert_eq!(import.gd_impl, true);
+    }
+
+    #[test]
     fn skip_directive() {
         let src = "
             // @typescript-to-gdscript-skip
@@ -3994,10 +4022,10 @@ mod tests {
     #[test]
     fn type_directive_local() {
         let src = "
-        // @typescript-to-gdscript-type: int
-        export type TeamId = number;
-        export interface A { interface_value: TeamId; }
-    ";
+            // @typescript-to-gdscript-type: int
+            export type TeamId = number;
+            export interface A { interface_value: TeamId; }
+        ";
         let models = parse_and_get_models("type-directive-across-modules.ts", &src);
         let interfaceValue = &models[0].var_descriptors[0];
         assert_eq!(interfaceValue.name, "interface_value");
@@ -4006,12 +4034,12 @@ mod tests {
     #[test]
     fn type_directive_on_property() {
         let src = "
-        export type TeamId = number;
-        export interface A { 
-            // @typescript-to-gdscript-type: unknown
-            interface_value: TeamId; 
-        }
-    ";
+            export type TeamId = number;
+            export interface A { 
+                // @typescript-to-gdscript-type: unknown
+                interface_value: TeamId; 
+            }
+        ";
         let models = parse_and_get_models("type-directive-on-property.ts", &src);
         let interfaceValue = &models[0].var_descriptors[0];
         assert_eq!(interfaceValue.name, "interface_value");
@@ -4021,13 +4049,13 @@ mod tests {
     #[ignore]
     fn type_directive_override_property() {
         let src = "
-        // @typescript-to-gdscript-type: int
-        export type TeamId = number;
-        export interface A { 
-            // @typescript-to-gdscript-type: unknown
-            interface_value: TeamId; 
-        }
-    ";
+            // @typescript-to-gdscript-type: int
+            export type TeamId = number;
+            export interface A { 
+                // @typescript-to-gdscript-type: unknown
+                interface_value: TeamId; 
+            }
+        ";
         let models = parse_and_get_models("type-directive-override-property.ts", &src);
         let interfaceValue = &models[0].var_descriptors[0];
         assert_eq!(interfaceValue.name, "interface_value");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1248,7 +1248,7 @@ fn resolve_type(
     context: &mut ModuleContext,
     ts_type: &TsType,
 ) -> TypeResolution {
-    match (ts_type) {
+    let result = match (ts_type) {
         TsType::TsTypeRef(type_ref) => {
             global
                 .stack
@@ -1310,7 +1310,6 @@ fn resolve_type(
                     global.get_info(context)
                 ),
             };
-            result = update_resolve_from_comments(context, result);
             global.stack.pop();
             result
         }
@@ -1376,7 +1375,8 @@ fn resolve_type(
             ts_type,
             global.get_info(context)
         ),
-    }
+    };
+    return update_resolve_from_comments(context, result);
 }
 
 fn lit_to_ts_lit(ts_lit: &Lit) -> TsLit {
@@ -1544,7 +1544,20 @@ fn resolve_local_specifier_type(
                     }
                 }
                 ModuleItem::Stmt(Stmt::Decl(decl)) => {
-                    let resolved = resolve_type_decl(global, context, &decl, &id);
+                    let alias_or_intf_pos = match decl {
+                        Decl::TsTypeAlias(alias) => Some(alias.span.to_owned()),
+                        Decl::TsInterface(intf) => Some(intf.span.to_owned()),
+                        _ => None,
+                    };
+
+                    let resolved = if let Some(new_pos) = alias_or_intf_pos {
+                        context.pos.push(new_pos);
+                        let res = resolve_type_decl(global, context, &decl, &id);
+                        context.pos.pop();
+                        res
+                    } else {
+                        resolve_type_decl(global, context, &decl, &id)
+                    };
                     if let Some(mut r) = resolved {
                         r.add_import(context);
                         decl_resolved = Some(r);
@@ -1795,7 +1808,6 @@ fn resolve_local_specifier_type_or_builtin(
 fn print_type_of<T>(_: &T) {
     println!("{}", std::any::type_name::<T>())
 }
-// TODO: resolve specifiers across modules until we find one that has @typescript-to-gdscript-type: int or something?
 fn resolve_imported_specifier_type<'a>(
     global: &mut Context,
     context: &'a ModuleContext,
@@ -1902,7 +1914,6 @@ fn resolve_type_decl(
     match decl {
         Decl::TsTypeAlias(alias) => {
             result = if match_id.0 == alias.id.to_id().0 {
-                context.pos.push(alias.span.to_owned());
                 global.stack.push(format!(
                     "resolve_type_decl:TsTypeAlias {}",
                     alias.id.to_id().0
@@ -1914,9 +1925,7 @@ fn resolve_type_decl(
                     context
                         .decl_stack
                         .push(ResolutionDecl::TsTypeAliasDecl(alias.to_owned()));
-                    context.id_stack.push(alias.id.to_id().to_owned());
                     let r = resolve_type(global, context, &alias.type_ann);
-                    context.id_stack.pop();
                     context.decl_stack.pop();
                     r
                 };
@@ -1925,7 +1934,6 @@ fn resolve_type_decl(
                 result.decl_context = Some(context.clone());
                 result.add_import(context);
                 global.stack.pop();
-                context.pos.pop();
                 Some(result)
             } else {
                 if global.debug_print {
@@ -1936,13 +1944,11 @@ fn resolve_type_decl(
         }
         Decl::TsInterface(intf) => {
             result = if match_id.0 == intf.id.to_id().0 {
-                context.pos.push(intf.span.to_owned());
                 let id = intf.id.to_id();
                 let mut result: TypeResolution = intf.id.clone().into();
                 result.decl = Some(ResolutionDecl::TsInterfaceDecl(intf.to_owned()));
                 result.decl_context = Some(context.clone());
                 result.ctor_type = Some(result.type_name.clone());
-                context.pos.pop();
                 Some(result)
             } else {
                 None
@@ -3963,5 +3969,128 @@ mod tests {
         assert_eq!(model.vars.len(), 1);
         let var_decl = model.vars.get(0).unwrap();
         var_decl.init == "Iso8601Date";
+    }
+
+    #[test]
+    fn type_directive_imported() {
+        let team_id = "
+            // @typescript-to-gdscript-type: int
+            export type TeamId = number;
+        ";
+        let src = "
+            import { TeamId } from \"./team-id.ts\";
+            export interface A { interface_value: TeamId; }
+        ";
+        let models = parse_and_get_models_with_imports(
+            "type-directive-imported.ts",
+            &src,
+            &[&parse_from_string("team-id.ts", team_id)],
+        );
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("int")));
+    }
+
+    #[test]
+    fn type_directive_local() {
+        let src = "
+        // @typescript-to-gdscript-type: int
+        export type TeamId = number;
+        export interface A { interface_value: TeamId; }
+    ";
+        let models = parse_and_get_models("type-directive-across-modules.ts", &src);
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("int")));
+    }
+    #[test]
+    fn type_directive_on_property() {
+        let src = "
+        export type TeamId = number;
+        export interface A { 
+            // @typescript-to-gdscript-type: unknown
+            interface_value: TeamId; 
+        }
+    ";
+        let models = parse_and_get_models("type-directive-on-property.ts", &src);
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("unknown")));
+    }
+    #[test]
+    #[ignore]
+    fn type_directive_override_property() {
+        let src = "
+        // @typescript-to-gdscript-type: int
+        export type TeamId = number;
+        export interface A { 
+            // @typescript-to-gdscript-type: unknown
+            interface_value: TeamId; 
+        }
+    ";
+        let models = parse_and_get_models("type-directive-override-property.ts", &src);
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("unknown")));
+    }
+
+    #[test]
+    fn type_directive_on_property_imported() {
+        let team_id = "
+            export type TeamId = number;
+        ";
+        let src = "
+            import { TeamId } from \"./team-id.ts\";
+            export interface A {
+                // @typescript-to-gdscript-type: unknown
+                interface_value: TeamId;
+            }
+        ";
+        let models = parse_and_get_models_with_imports(
+            "type-directive-on-property-imported.ts",
+            &src,
+            &[&parse_from_string("team-id.ts", team_id)],
+        );
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("unknown")));
+    }
+
+    #[test]
+    fn type_directive_override_property_imported() {
+        let team_id = "
+            // @typescript-to-gdscript-type: int
+            export type TeamId = number;
+        ";
+        let src = "
+            import { TeamId } from \"./team-id.ts\";
+            export interface A {
+                // @typescript-to-gdscript-type: unknown
+                interface_value: TeamId;
+            }
+        ";
+        let models = parse_and_get_models_with_imports(
+            "type-directive-override-property-imported.ts",
+            &src,
+            &[&parse_from_string("team-id.ts", team_id)],
+        );
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("unknown")));
+    }
+
+    #[test]
+    #[ignore]
+    fn type_directive_on_builtin_property() {
+        let src = "
+            export interface A { 
+                // @typescript-to-gdscript-type: unknown
+                interface_value: Array<number>; 
+            }
+        ";
+        let models = parse_and_get_models("type-directive-on-builtin-property.ts", &src);
+        let interfaceValue = &models[0].var_descriptors[0];
+        assert_eq!(interfaceValue.name, "interface_value");
+        assert_eq!(interfaceValue.decl_type, Some(String::from("unknown")));
     }
 }


### PR DESCRIPTION
Previously, using imported interfaces that have a gd-impl directive had an issue where it didn't use the "../" path to find the manually implemented class. It simply wasn't updating the gd_impl directive correctly here.

This PR fixes this issue, and adds tests.

This change is waiting on #2 