### PR TITLE
Resolve Godot Warnings (change __assigned_properties to use `false`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # typescript-to-gdscript
 
-Convert TypeScript type definitions into concrete models in GDScript for godot
+Convert TypeScript type definitions into concrete models in GDScript for Godot 4.4
 
 This utility enables a pipeline where TypeScript files containing interfaces can be transformed into gdscript classes.
 
@@ -161,11 +161,11 @@ func _init(src: Dictionary = {}, partial_deep = false) -> void:
 		update(src)
 
 func __set_optional_date(value: Iso8601Date):
-	__assigned_properties.optional_date = true if typeof(value) != TYPE_NIL else null
+	__assigned_properties.optional_date = true if value != null else null
 	optional_date = value
 
 func __set_nullable_optional_date(value: Iso8601Date):
-	__assigned_properties.nullable_optional_date = true if typeof(value) != TYPE_NIL else null
+	__assigned_properties.nullable_optional_date = true if value != null else null
 	nullable_optional_date = value
 
 
@@ -188,8 +188,8 @@ func update(src: Dictionary) -> void:
 		__assigned_properties.optional_date = true
 		optional_date = Iso8601Date.new(src.optionalDate, __partial_deep)
 	if "nullableOptionalDate" in src:
-		__assigned_properties.nullable_optional_date = true if typeof(src.nullableOptionalDate) != TYPE_NIL else null
-		nullable_optional_date = Iso8601Date.new(src.nullableOptionalDate, __partial_deep) if typeof(src.nullableOptionalDate) != TYPE_NIL else null
+		__assigned_properties.nullable_optional_date = true if src.nullableOptionalDate != null else null
+		nullable_optional_date = Iso8601Date.new(src.nullableOptionalDate, __partial_deep) if src.nullableOptionalDate != null else null
 	if !__partial_deep || "date" in src:
 		__assigned_properties.date = true
 		date = Iso8601Date.new(src.date, __partial_deep)
@@ -250,7 +250,7 @@ func for_json() -> Dictionary:
 	if is_set("optional_date"):
 		result.optionalDate = optional_date.for_json()
 	if is_set("nullable_optional_date"):
-		result.nullableOptionalDate = nullable_optional_date.for_json() if typeof(nullable_optional_date) != TYPE_NIL else null
+		result.nullableOptionalDate = nullable_optional_date.for_json() if nullable_optional_date != null else null
 	if !__partial_deep || is_set("date"):
 		result.date = date.for_json()
 	if !__partial_deep || is_set("str_lit"):

--- a/gdscript-model.gd.tmpl
+++ b/gdscript-model.gd.tmpl
@@ -1,3 +1,4 @@
+@warning_ignore_start("incompatible_ternary")
 extends RefCounted
 {{- if comment }}
 # {comment}
@@ -37,7 +38,7 @@ func _init(src: { src_type.name } {{ if src_type.init }}= {src_type.init}{{ endi
 		update(src)
 {{ for var_decl in var_descriptors }}{{ if var_decl.optional }}
 func __set_{var_decl.name}(__value__{{ if var_decl.decl_type }}: {var_decl.decl_type}{{ endif }}):
-	__assigned_properties.{var_decl.name} = true if typeof(__value__) != TYPE_NIL else null
+	__assigned_properties.{var_decl.name} = true if __value__ != null else null
 	{var_decl.name} = __value__
 {{ endif }}{{ endfor }}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2462,23 +2462,23 @@ mod tests {
         }
         assert_eq!(
             vars.get("obj").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else null"
+            " != null else null"
         );
         assert_eq!(
             vars.get("str").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else \"\""
+            " != null else \"\""
         );
         assert_eq!(
             vars.get("int").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else 0"
+            " != null else 0"
         );
         assert_eq!(
             vars.get("float").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else 0.0"
+            " != null else 0.0"
         );
         assert_eq!(
             vars.get("bool").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else false"
+            " != null else false"
         );
     }
 
@@ -2525,19 +2525,19 @@ mod tests {
         }
         assert_eq!(
             vars.get("str").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else \"\""
+            " != null else \"\""
         );
         assert_eq!(
             vars.get("int").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else 0"
+            " != null else 0"
         );
         assert_eq!(
             vars.get("float").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else 0.0"
+            " != null else 0.0"
         );
         assert_eq!(
             vars.get("bool").unwrap().ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else false"
+            " != null else false"
         );
     }
 
@@ -2607,11 +2607,11 @@ mod tests {
         );
         assert_eq!(
             opt_a_of_str_or_null.ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else \"\""
+            " != null else \"\""
         );
         assert_eq!(
             opt_a_of_member_or_null.ctor.suffix.as_ref().unwrap(),
-            ") != TYPE_NIL else null"
+            " != null else null"
         );
     }
 

--- a/src/model_context.rs
+++ b/src/model_context.rs
@@ -142,10 +142,10 @@ impl ModelValueCtor {
             end: if !nullable {
                 rparen_str.to_string()
             } else {
-                format!("{} if typeof(", rparen_str)
+                format!("{} if ", rparen_str)
             },
             suffix: if nullable {
-                Some(format!(") != TYPE_NIL else {}", null_value))
+                Some(format!(" != null else {}", null_value))
             } else {
                 None
             },
@@ -162,7 +162,7 @@ pub struct ModelValueCtor {
     pub end: String,
     // suffix such for cases where we need to put the input value in twice
     // usage: `{ctor.start}__value__{ctor.end}{{if ctor.suffix}}__value__{ctor.suffix}{{endif}}
-    // for cases like `T.new(__value__) if typeof(__value__) != TYPE_NIL else null`
+    // for cases like `T.new(__value__) if __value__ != null else null`
     pub suffix: Option<String>,
 }
 
@@ -178,7 +178,7 @@ impl ModelValueForJson {
         let (null_test_start, null_test_end) = if builtin {
             (" if !is_null(\"", "\")")
         } else {
-            (" if typeof(", ") != TYPE_NIL")
+            (" if ", " != null")
         };
         ModelValueForJson {
             name: name.to_string(),
@@ -363,7 +363,7 @@ impl ModelVarDescriptor {
             self.ctor.suffix.is_some()
         };
         let assigned_value = if src_nullable {
-            format!("true if typeof({src_specifier}) != TYPE_NIL else null")
+            format!("true if {src_specifier} != null else null")
         } else {
             "true".to_string()
         };
@@ -387,7 +387,7 @@ impl ModelVarDescriptor {
             ));
             if collection.nullable {
                 parts.push(add_indent(
-                    format!("if typeof({src_specifier}) != TYPE_NIL:"),
+                    format!("if {src_specifier} != null:"),
                     indent,
                     indent_level,
                 ));
@@ -793,8 +793,8 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null\n\
-                {ws}prop_name = Intf.new(src.propName, __partial_deep) if typeof(src.propName) != TYPE_NIL else null\
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null\n\
+                {ws}prop_name = Intf.new(src.propName, __partial_deep) if src.propName != null else null\
             "})
         );
     }
@@ -822,8 +822,8 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null\n\
-                {ws}prop_name = src.propName if typeof(src.propName) != TYPE_NIL else \"\"\
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null\n\
+                {ws}prop_name = src.propName if src.propName != null else \"\"\
             "})
         );
     }
@@ -850,8 +850,8 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
-                {ws}prop_name = Intf.new(src.propName, __partial_deep) if typeof(src.propName) != TYPE_NIL else null\
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
+                {ws}prop_name = Intf.new(src.propName, __partial_deep) if src.propName != null else null\
             "})
         );
     }
@@ -881,8 +881,8 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
-                {ws}prop_name = src.propName if typeof(src.propName) != TYPE_NIL else \"\"\
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
+                {ws}prop_name = src.propName if src.propName != null else \"\"\
             "})
         );
     }
@@ -947,9 +947,9 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = []
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __item__ in src.propName:
                 {ws}{ws}{ws}var __value__ = Intf.new(__item__, __partial_deep)
                 {ws}{ws}{ws}prop_name.append(__value__)\
@@ -971,9 +971,9 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
                 {ws}{ws}{ws}prop_name[__key__] = Intf.new(__value__, __partial_deep)\
@@ -995,11 +995,11 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = []
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __item__ in src.propName:
-                {ws}{ws}{ws}var __value__ = Intf.new(__item__, __partial_deep) if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = Intf.new(__item__, __partial_deep) if __item__ != null else null
                 {ws}{ws}{ws}prop_name.append(__value__)\
             "})
         );
@@ -1019,12 +1019,12 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
-                {ws}{ws}{ws}prop_name[__key__] = Intf.new(__value__, __partial_deep) if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}prop_name[__key__] = Intf.new(__value__, __partial_deep) if __value__ != null else null\
             "})
         );
     }
@@ -1043,11 +1043,11 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = []
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __item__ in src.propName:
-                {ws}{ws}{ws}var __value__ = Intf.new(__item__, __partial_deep) if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = Intf.new(__item__, __partial_deep) if __item__ != null else null
                 {ws}{ws}{ws}prop_name.append(__value__)\
             "})
         );
@@ -1067,12 +1067,12 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
-                {ws}{ws}{ws}prop_name[__key__] = Intf.new(__value__, __partial_deep) if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}prop_name[__key__] = Intf.new(__value__, __partial_deep) if __value__ != null else null\
             "})
         );
     }
@@ -1093,11 +1093,11 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = []
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __item__ in src.propName:
-                {ws}{ws}{ws}var __value__ = __item__ if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = __item__ if __item__ != null else null
                 {ws}{ws}{ws}prop_name.append(__value__)\
             "})
         );
@@ -1117,12 +1117,12 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
-                {ws}{ws}{ws}prop_name[__key__] = __value__ if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}prop_name[__key__] = __value__ if __value__ != null else null\
             "})
         );
     }
@@ -1148,7 +1148,7 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if !__partial_deep || is_set(\"prop_name\"):
-                {ws}result.propName = prop_name.for_json() if typeof(prop_name) != TYPE_NIL else null\
+                {ws}result.propName = prop_name.for_json() if prop_name != null else null\
             "})
         );
     }
@@ -1201,7 +1201,7 @@ pub mod tests {
             rendered,
             indent(formatdoc! {"
                 if is_set(\"prop_name\"):
-                {ws}result.propName = prop_name.for_json() if typeof(prop_name) != TYPE_NIL else null\
+                {ws}result.propName = prop_name.for_json() if prop_name != null else null\
             "})
         );
     }
@@ -1348,7 +1348,7 @@ pub mod tests {
                 {ws}else:
                 {ws}{ws}result.propName = []
                 {ws}{ws}for __item__ in prop_name:
-                {ws}{ws}{ws}var __value__ = __item__.for_json() if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = __item__.for_json() if __item__ != null else null
                 {ws}{ws}{ws}result.propName.append(__value__)\
             "})
         );
@@ -1374,7 +1374,7 @@ pub mod tests {
                 {ws}{ws}result.propName = {{}}
                 {ws}{ws}for __key__ in prop_name:
                 {ws}{ws}{ws}var __value__ = prop_name[__key__]
-                {ws}{ws}{ws}result.propName[__key__] = __value__.for_json() if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}result.propName[__key__] = __value__.for_json() if __value__ != null else null\
             "})
         );
     }
@@ -1398,7 +1398,7 @@ pub mod tests {
                 {ws}else:
                 {ws}{ws}result.propName = []
                 {ws}{ws}for __item__ in prop_name:
-                {ws}{ws}{ws}var __value__ = __item__.for_json() if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = __item__.for_json() if __item__ != null else null
                 {ws}{ws}{ws}result.propName.append(__value__)\
             "})
         );
@@ -1424,7 +1424,7 @@ pub mod tests {
                 {ws}{ws}result.propName = {{}}
                 {ws}{ws}for __key__ in prop_name:
                 {ws}{ws}{ws}var __value__ = prop_name[__key__]
-                {ws}{ws}{ws}result.propName[__key__] = __value__.for_json() if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}result.propName[__key__] = __value__.for_json() if __value__ != null else null\
             "})
         );
     }
@@ -1450,7 +1450,7 @@ pub mod tests {
                 {ws}else:
                 {ws}{ws}result.propName = []
                 {ws}{ws}for __item__ in prop_name:
-                {ws}{ws}{ws}var __value__ = __item__ if typeof(__item__) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__ = __item__ if __item__ != null else null
                 {ws}{ws}{ws}result.propName.append(__value__)\
             "})
         );
@@ -1476,7 +1476,7 @@ pub mod tests {
                 {ws}{ws}result.propName = {{}}
                 {ws}{ws}for __key__ in prop_name:
                 {ws}{ws}{ws}var __value__ = prop_name[__key__]
-                {ws}{ws}{ws}result.propName[__key__] = __value__ if typeof(__value__) != TYPE_NIL else null\
+                {ws}{ws}{ws}result.propName[__key__] = __value__ if __value__ != null else null\
             "})
         );
     }
@@ -1501,15 +1501,15 @@ pub mod tests {
             indent(
                 formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
                 {ws}{ws}{ws}var __coll__ = []
                 {ws}{ws}{ws}prop_name[__key__] = __coll__
                 {ws}{ws}{ws}for __item__1 in __value__:
-                {ws}{ws}{ws}{ws}var __value__1 = B.new(__item__1, __partial_deep) if typeof(__item__1) != TYPE_NIL else null
+                {ws}{ws}{ws}{ws}var __value__1 = B.new(__item__1, __partial_deep) if __item__1 != null else null
                 {ws}{ws}{ws}{ws}__coll__.append(__value__1)\
                 "}
                 .to_string()
@@ -1537,15 +1537,15 @@ pub mod tests {
             indent(
                 formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = []
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __item__ in src.propName:
                 {ws}{ws}{ws}var __coll__ = {{}}
                 {ws}{ws}{ws}prop_name.append(__coll__)
                 {ws}{ws}{ws}for __key__1 in __item__:
                 {ws}{ws}{ws}{ws}var __value__1 = __item__[__key__1]
-                {ws}{ws}{ws}{ws}__coll__[__key__1] = B.new(__value__1, __partial_deep) if typeof(__value__1) != TYPE_NIL else null\
+                {ws}{ws}{ws}{ws}__coll__[__key__1] = B.new(__value__1, __partial_deep) if __value__1 != null else null\
                 "}
                 .to_string()
             )
@@ -1572,15 +1572,15 @@ pub mod tests {
             indent(
                 formatdoc! {"
                 if !__partial_deep || \"propName\" in src:
-                {ws}__assigned_properties.prop_name = true if typeof(src.propName) != TYPE_NIL else null
+                {ws}__assigned_properties.prop_name = true if src.propName != null else null
                 {ws}prop_name = {{}}
-                {ws}if typeof(src.propName) != TYPE_NIL:
+                {ws}if src.propName != null:
                 {ws}{ws}for __key__ in src.propName:
                 {ws}{ws}{ws}var __value__ = src.propName[__key__]
                 {ws}{ws}{ws}var __coll__ = []
                 {ws}{ws}{ws}prop_name[__key__] = __coll__
                 {ws}{ws}{ws}for __item__1 in __value__:
-                {ws}{ws}{ws}{ws}var __value__1 = __item__1 if typeof(__item__1) != TYPE_NIL else null
+                {ws}{ws}{ws}{ws}var __value__1 = __item__1 if __item__1 != null else null
                 {ws}{ws}{ws}{ws}__coll__.append(__value__1)\
                 "}
                 .to_string()
@@ -1613,7 +1613,7 @@ pub mod tests {
                 {ws}{ws}var __coll__ = []
                 {ws}{ws}result.propName[__key__] = __coll__
                 {ws}{ws}for __item__1 in __value__:
-                {ws}{ws}{ws}var __value__1 = __item__1.for_json() if typeof(__item__1) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__1 = __item__1.for_json() if __item__1 != null else null
                 {ws}{ws}{ws}__coll__.append(__value__1)\
             "})
         );
@@ -1644,7 +1644,7 @@ pub mod tests {
                 {ws}{ws}result.propName.append(__coll__)
                 {ws}{ws}for __key__1 in __item__:
                 {ws}{ws}{ws}var __value__1 = __item__[__key__1]
-                {ws}{ws}{ws}__coll__[__key__1] = __value__1.for_json() if typeof(__value__1) != TYPE_NIL else null\
+                {ws}{ws}{ws}__coll__[__key__1] = __value__1.for_json() if __value__1 != null else null\
             "})
         );
     }
@@ -1674,7 +1674,7 @@ pub mod tests {
                 {ws}{ws}var __coll__ = []
                 {ws}{ws}result.propName[__key__] = __coll__
                 {ws}{ws}for __item__1 in __value__:
-                {ws}{ws}{ws}var __value__1 = __item__1 if typeof(__item__1) != TYPE_NIL else null
+                {ws}{ws}{ws}var __value__1 = __item__1 if __item__1 != null else null
                 {ws}{ws}{ws}__coll__.append(__value__1)\
             "})
         );


### PR DESCRIPTION
This fixes the default warning generated from ternary types being incompatible
Also change to just compare with null directly

Uses a feature to ignore warnings from 4.4